### PR TITLE
Prepare first Release of Windman

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: ci
+
+on:
+  push:
+    branches: [ main, develop, feat/** ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  lint-commits:
+    name: Lint commits (conventional)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # commitlint needs history
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install commitlint deps
+        run: npm install --no-audit --no-fund
+
+      - name: Commitlint
+        uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: commitlint.config.js
+
+
+  build-test:
+    name: Build • Test • Clippy
+    runs-on: ubuntu-latest
+    needs: [lint-commits]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Task
+        uses: arduino/setup-task@v1
+      - name: Run Task CI
+        run: task ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*.*.*'   # e.g. 1.2.3 (no leading 'v')
+
+env:
+  BINARY_NAME: windman
+
+jobs:
+  build-linux:
+    name: Build Linux (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Only needed for cross-linking aarch64 GNU on x64 runner
+      - name: Install cross linker (aarch64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+
+      - name: Build & Dist (${{ matrix.target }})
+        run: |
+          rustup target add ${{ matrix.target }} || true
+          task dist:linux TARGET=${{ matrix.target }}
+
+      - name: Generate SBOM (CycloneDX, ${{ matrix.target }})
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: dist/sbom-${{ matrix.target }}.cdx.json
+
+      - name: Upload artifacts (${{ matrix.target }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ matrix.target }}-dist
+          path: dist/*
+
+  release:
+    name: Create GitHub Release
+    needs: [build-linux]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for changelog range
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: _artifacts
+
+      - name: Merge artifacts to dist/
+        run: |
+          mkdir -p dist
+          cp -r _artifacts/*/* dist/ || true
+          ls -l dist
+
+      - name: Create combined SHA256SUMS
+        run: |
+          (cd dist && cat *.sha256 > SHA256SUMS)
+          echo "SHA256SUMS:"
+          cat dist/SHA256SUMS
+
+      - name: Generate conventional changelog
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: false
+          skip-commit: true
+          skip-tag: true
+          preset: conventionalcommits
+          git-message: "chore(release): {version}"
+          release-count: 0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}     # e.g. 1.2.3
+          tag_name: ${{ github.ref_name }} # e.g. 1.2.3
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          files: |
+            dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Rust / Cargo
+target/
+Cargo.lock
+
+# Binaries (built or temp)
+*.exe
+*.dll
+*.so
+*.dylib
+*.pdb
+
+# Backups & temp
+*.swp
+*.swo
+*.tmp
+*.bak
+*.old
+
+# Logs
+*.log
+
+# macOS
+.DS_Store
+
+# Linux
+*~
+
+# Windows
+Thumbs.db
+Desktop.ini
+
+# IDEs / Editors
+.vscode/
+.idea/
+*.iml
+
+# Custom (optional for Windman)
+# ignore fake test tarballs if generated under repo
+windsurf-linux-x64-*.tar.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "windman"
+version = "0.1.0"
+edition = "2021"
+
+
+[dependencies]
+anyhow = "1.0.86"
+thiserror = "1.0.63"
+clap = { version = "4.5.7", features = ["derive", "env"] }
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"
+toml = "0.8.19"
+# Networking will be added in the next step (reqwest + rustls). For now, local --tar install works.
+reqwest = { version = "0.12.4", default-features = false, features = ["rustls-tls", "gzip", "brotli", "json", "blocking"] }
+flate2 = "1.0.30"
+tar = "0.4.41"
+sha2 = "0.10.8"
+hex = "0.4.3"
+indicatif = "0.17.8"
+directories = "5.0.1"
+walkdir = "2.5.0"
+fs4 = "0.7.0"
+tempfile = "3.10.1"
+chrono = { version = "0.4.38", features = ["clock"] }
+shellexpand = "3.1.0"
+semver = "1.0.23"
+scraper = "0.19.0"
+regex = "1.10.6"
+
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,132 @@
-# Windman
+# Windman — Windsurf Manager (userland, standalone)
+
+Windman is a tiny CLI to manage the **Windsurf** IDE on systems without native packages (e.g., Arch Linux).  
+It installs **userland/standalone** (no root), keeps a versioned directory layout, and switches atomically via a `current` symlink and a shell shim.
+
+> Status: MVP. **Stable** channel only.
+
+## Highlights
+
+- **Userland** installs by default under:
+  - Prefix: `~/.local/opt/windsurf`
+  - Shim: `~/.local/bin/windsurf` → launches `$prefix/current/Windsurf/bin/windsurf`
+- **Versioned installs** (`1.12.x`…); atomic switch via `current` symlink
+- **Update** from official endpoint (**Linux only**)
+- **List / Status / Rollback / Use <version> / Uninstall**
+- **Keep policy**: keep N newest versions; protects current and *previous-current* for safe rollback
+- **Desktop integration** (optional; enabled by default)
+- Config file in `~/.config/windman/windman.toml`
+
+## Why userland / standalone?
+
+- Decoupled from distro package managers (fits Arch/AUR-less setups)
+- No root needed; no `/opt` layout required (but supported if you change the prefix)
+- Easy rollback/switch between versions
+
+## Install (from source)
+
+```bash
+git clone https://github.com/<you>/Windman
+cd Windman
+cargo build --release
+# Add to PATH or copy:
+install -Dm755 target/release/windman ~/.local/bin/windman
+```
+
+## Quick start
+
+```bash
+# Initialize config with sensible defaults
+windman config init
+
+# Show effective config (paths resolved)
+windman config show
+
+# Install/update to the latest stable (Linux)
+windman update
+
+# Status / list versions
+windman status
+windman list
+
+# Switch manually
+windman use 1.12.11
+
+# Rollback to the previous current
+windman rollback
+
+# Uninstall (keeps user data)
+windman uninstall
+```
+
+## Configuration
+
+`~/.config/windman/windman.toml` (default):
+
+```toml
+[install]
+prefix_dir = "~/.local/opt/windsurf"
+bin_dir = "~/.local/bin"
+channel = "stable"
+keep = 2
+desktop_integration = true
+
+[network]
+proxy_enabled = false  # reserved for future proxy support
+```
+
+You can **override per-run**:
+```bash
+windman --prefix ~/Dev/windsurf --bin-dir ~/bin update
+```
+
+## Commands
+
+- `update` — fetch latest stable (Linux) and install  
+- `install --tar <FILE>` — install from a local tarball (useful for offline/test)  
+- `list` — list installed versions; mark current  
+- `status` — show paths and current version  
+- `use <version>` — switch to a specific installed version  
+- `rollback` — switch back to previous current  
+- `uninstall` — remove installs and shim (optionally desktop files)  
+- `where` — print paths  
+- `config init/show` — manage config  
+
+## Keep policy & safety
+
+- `install.keep = N` keeps the **N newest** versions  
+- Windman **always preserves**:  
+  - the **current** version after the update  
+  - the **previous-current** (the one that was active before the update)  
+- This guarantees a safe one-step rollback after every update.  
+
+## Targets
+
+- **Linux x86_64**: `x86_64-unknown-linux-gnu`  
+- **Linux AArch64**: `aarch64-unknown-linux-gnu`  
+- macOS is **out of scope** for Windman (Windsurf provides its own macOS installer).
+
+## Development
+
+```bash
+# Format & lint
+cargo fmt
+cargo clippy -- -D warnings
+
+# Test
+cargo test
+
+# Taskfile (same locally and in CI)
+task build
+task test
+task ci
+
+# Package (host target by default; or set TARGET explicitly)
+task dist:linux
+task dist:linux TARGET=x86_64-unknown-linux-gnu
+task dist:linux TARGET=aarch64-unknown-linux-gnu
+```
+
+## License
+
+MIT (or choose your license). © You.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,97 @@
+version: '3'
+
+tasks:
+  fmt:
+    desc: "CI pipeline: fmt + clippy + test + build"
+    cmds:
+      - cargo fmt
+
+  clippy:
+    desc: "Run clippy with -D warnings"
+    cmds:
+      - cargo clippy -- -D warnings
+
+  test:
+    desc: "Run unit tests"
+    cmds:
+      - cargo test --all --locked
+
+  build:
+    desc: "Build release (native target)"
+    cmds:
+      - cargo build --release --locked
+
+  ci:
+    desc: "CI pipeline: fmt + clippy + test + build"
+    cmds:
+      - task fmt
+      - task clippy
+      - task test
+      - task build
+
+  dist:linux:
+    desc: "Package tar.gz + SHA256 for a target (defaults to host target)"
+    # Usage:
+    #   task dist:linux               # host target
+    #   task dist:linux TARGET=x86_64-unknown-linux-gnu
+    #   task dist:linux TARGET=aarch64-apple-darwin
+    env:
+      DIST_DIR: dist
+      BINARY_NAME: windman
+    cmds:
+      - |
+        set -euo pipefail
+
+        # Compute VERSION: prefer git tag, else Cargo.toml; strip any leading 'v' defensively
+        if VERSION_RAW="$(git describe --tags --dirty --always 2>/dev/null)"; then
+          VERSION="${VERSION_RAW#v}"
+        else
+          VERSION="$(awk -F '"' '/^version\s*=\s*/{print $2; exit}' Cargo.toml)"
+        fi
+
+        # Compute TARGET: default to host unless TARGET is provided
+        if [ -z "${TARGET:-}" ]; then
+          TARGET="$(rustc -vV | awk -F '[: ]+' '/host:/{print $2}')"
+        fi
+
+        echo "Version: ${VERSION}"
+        echo "Target : ${TARGET}"
+
+        mkdir -p "${DIST_DIR}"
+
+        HOST="$(rustc -vV | awk -F '[: ]+' '/host:/{print $2}')"
+        if [ "${TARGET}" = "${HOST}" ]; then
+          cargo build --release --locked
+          BIN="target/release/${BINARY_NAME}"
+        else
+          rustup target add "${TARGET}" || true
+          cargo build --release --locked --target "${TARGET}"
+          BIN="target/${TARGET}/release/${BINARY_NAME}"
+        fi
+
+        OUT_DIR="${DIST_DIR}/${BINARY_NAME}-${VERSION}-${TARGET}"
+        mkdir -p "${OUT_DIR}"
+        cp "${BIN}" "${OUT_DIR}/"
+        [ -f README.md ] && cp README.md "${OUT_DIR}/" || true
+        [ -f LICENSE ] && cp LICENSE "${OUT_DIR}/" || true
+
+        tar -C "${DIST_DIR}" -czf "${OUT_DIR}.tar.gz" "$(basename "${OUT_DIR}")"
+        (cd "${DIST_DIR}" && sha256sum "$(basename "${OUT_DIR}").tar.gz" > "$(basename "${OUT_DIR}").tar.gz.sha256")
+
+        ls -l "${DIST_DIR}"
+
+  clean:
+    desc: "Clean target and dist"
+    cmds:
+      - cargo clean
+      - rm -rf dist
+
+  version:
+    desc: "Print computed version (git tag or Cargo.toml), v-stripped"
+    cmds:
+      - |
+        if VERSION_RAW="$(git describe --tags --dirty --always 2>/dev/null)"; then
+          echo "${VERSION_RAW#v}"
+        else
+          awk -F '"' '/^version\s*=\s*/{print $2; exit}' Cargo.toml
+        fi

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+      'subject-case': [0],
+    },
+  };
+  

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "windman-devtools",
+    "private": true,
+    "devDependencies": {
+      "@commitlint/cli": "^17.7.2",
+      "@commitlint/config-conventional": "^17.7.0"
+    }
+  }
+  

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,583 @@
+use crate::config::{Config, ConfigPaths};
+use crate::paths::resolve_paths;
+use crate::{desktop, install, prune, version};
+use anyhow::{bail, Result};
+use clap::{Args, Parser, Subcommand};
+use std::fs;
+#[derive(Parser, Debug)]
+#[command(
+    name = "windman",
+    version,
+    about = "Windsurf Manager (userland, standalone)"
+)]
+pub struct Cli {
+    /// Override config path
+    #[arg(long, global = true, env = "WINDMAN_CONFIG_PATH")]
+    pub config: Option<String>,
+
+    /// Override install prefix directory for this run (e.g., ~/.local/opt/windsurf)
+    #[arg(long, global = true, value_name = "DIR")]
+    pub prefix: Option<String>,
+
+    /// Override bin dir for this run (where the shim 'windsurf' is written)
+    #[arg(long, global = true, value_name = "DIR")]
+    pub bin_dir: Option<String>,
+
+    /// Verbose output
+    #[arg(short, long, global = true)]
+    pub verbose: bool,
+
+    #[command(subcommand)]
+    pub cmd: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Download + install latest stable (next step). For now: install from a provided tar.gz.
+    Install(InstallArgs),
+    /// Compare local vs remote and update if needed
+    Update(UpdateArgs),
+    /// Show local version and paths
+    Status,
+    /// Print install and shim paths
+    Where,
+    /// List installed versions and show current
+    List,
+    /// Show changelog delta (coming soon)
+    Changelog,
+    /// Remove installs and shims (keeps user data)
+    Uninstall {
+        #[arg(long)]
+        purge: bool,
+    },
+    /// Switch back to previous kept version
+    Rollback,
+
+    /// Switch current to a specific installed version (e.g., windman use 1.12.11)
+    Use(UseArgs),
+
+    /// Manage configuration
+    #[command(subcommand)]
+    Config(ConfigCmd),
+
+    /// Internal helper to test latest endpoint (hidden in help)
+    #[command(hide = true)]
+    DevLatest(DevLatestArgs),
+
+    /// Internal helper to test the downloader (hidden in help)
+    #[command(hide = true)]
+    DevDownload(DevDownloadArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct UseArgs {
+    /// Version folder name to activate (e.g., 1.12.11)
+    #[arg(value_name = "VERSION")]
+    pub version: String,
+
+    /// Dry-run: show what would change without touching the system
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct DevLatestArgs {
+    #[arg(long)]
+    pub timeout: Option<u64>,
+    #[arg(long)]
+    pub dump_html: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct InstallArgs {
+    /// Path to a local Windsurf tar.gz (temporary until network fetch is added)
+    #[arg(long, value_name = "FILE")]
+    pub tar: Option<String>,
+
+    /// Force desktop integration even if disabled in config
+    #[arg(long)]
+    pub desktop: bool,
+
+    /// Do not create/update desktop integration for this run
+    #[arg(long)]
+    pub no_desktop: bool,
+
+    /// Keep N previous versions (overrides config)
+    #[arg(long, value_name = "N")]
+    pub keep: Option<usize>,
+
+    /// Dry-run: print actions without changing the system
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct UpdateArgs {
+    /// Force desktop integration for this run
+    #[arg(long)]
+    pub desktop: bool,
+
+    /// Do not create/update desktop integration for this run
+    #[arg(long)]
+    pub no_desktop: bool,
+
+    /// Dry-run
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigCmd {
+    /// Create default config file if missing
+    Init,
+    /// Show effective config (after env overrides)
+    Show,
+}
+
+#[derive(Args, Debug)]
+pub struct DevDownloadArgs {
+    /// URL to download
+    #[arg(long)]
+    pub url: String,
+
+    /// Output file path
+    #[arg(long)]
+    pub out: String,
+
+    /// Request timeout in seconds (overrides default 30s)
+    #[arg(long)]
+    pub timeout: Option<u64>,
+}
+
+pub(crate) fn collect_installed(eff: &crate::paths::EffectivePaths) -> Vec<(String, bool)> {
+    use std::fs;
+    use std::path::Path;
+
+    let mut entries = Vec::new();
+    let current_target = fs::read_link(&eff.current_symlink).ok();
+
+    if eff.versions_dir.exists() {
+        if let Ok(rd) = fs::read_dir(&eff.versions_dir) {
+            for ent in rd.flatten() {
+                let path = ent.path();
+                let file_name = ent.file_name();
+                let name = file_name.to_string_lossy().to_string();
+
+                if name == "current" {
+                    continue;
+                }
+                if path.is_dir() {
+                    let is_current = match &current_target {
+                        Some(ct) => Path::new(ct).file_name() == Some(file_name.as_ref()),
+                        None => false,
+                    };
+                    entries.push((name, is_current));
+                }
+            }
+        }
+    }
+
+    // tri (semver desc > lexico desc)
+    entries.sort_by(|a, b| {
+        let asv = semver::Version::parse(&a.0);
+        let bsv = semver::Version::parse(&b.0);
+        match (asv, bsv) {
+            (Ok(av), Ok(bv)) => bv.cmp(&av),
+            _ => b.0.cmp(&a.0),
+        }
+    });
+    entries
+}
+
+pub(crate) fn switch_to_version(
+    eff: &crate::paths::EffectivePaths,
+    version: &str,
+) -> anyhow::Result<()> {
+    let target = eff.versions_dir.join(version);
+    if !target.is_dir() {
+        // Préparer un message d’erreur utile avec les versions dispo
+        let mut available = Vec::new();
+        if eff.versions_dir.exists() {
+            if let Ok(rd) = fs::read_dir(&eff.versions_dir) {
+                for ent in rd.flatten() {
+                    let p = ent.path();
+                    if p.is_dir() {
+                        if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
+                            if name != "current" {
+                                available.push(name.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        available.sort();
+        anyhow::bail!(
+            "version '{}' not found under {}.\nAvailable: {}",
+            version,
+            eff.versions_dir.display(),
+            if available.is_empty() {
+                "<none>".to_string()
+            } else {
+                available.join(", ")
+            }
+        );
+    }
+
+    // Si current pointe déjà sur cette version, rien à faire
+    if let Ok(cur) = fs::read_link(&eff.current_symlink) {
+        if cur == target {
+            println!("Already using {}.", version);
+            return Ok(());
+        }
+    }
+
+    crate::util::atomic_symlink_switch(&target, &eff.current_symlink)?;
+    println!("Now using {}.", version);
+    Ok(())
+}
+
+impl Cli {
+    pub fn parse() -> Self {
+        <Cli as Parser>::parse()
+    }
+
+    pub fn run(&self) -> Result<()> {
+        let cfg_paths = ConfigPaths::from_override(self.config.as_deref());
+        let mut cfg = Config::load_or_default(&cfg_paths)?;
+
+        // Appliquer les overrides globaux (courte vie, n’écrit pas la config)
+        if let Some(p) = &self.prefix {
+            cfg.install.prefix_dir = p.clone();
+        }
+        if let Some(b) = &self.bin_dir {
+            cfg.install.bin_dir = b.clone();
+        }
+
+        let eff = resolve_paths(&cfg)?;
+
+        if self.verbose {
+            eprintln!("[windman] Using config at {}", cfg_paths.config_display());
+            eprintln!("[windman] Effective prefix: {}", eff.prefix_dir.display());
+            eprintln!("[windman] Effective bin   : {}", eff.bin_dir.display());
+        }
+
+        match &self.cmd {
+            Commands::Install(args) => {
+                use std::path::PathBuf;
+
+                let keep = args.keep.unwrap_or(cfg.install.keep);
+                if args.dry_run {
+                    println!("[dry-run] would install to {:?}", eff.prefix_dir);
+                    println!("[dry-run] would maintain shim at {:?}", eff.bin_shim);
+                    return Ok(());
+                }
+
+                if let Some(tar) = &args.tar {
+                    // mémoriser la current avant bascule
+                    let previous_current: Option<PathBuf> =
+                        std::fs::read_link(&eff.current_symlink).ok();
+
+                    let ver = install::install_from_tar(tar, &eff)?;
+                    println!("Installed Windsurf {} to {:?}", ver, eff.prefix_dir);
+
+                    let want_desktop = if args.no_desktop {
+                        false
+                    } else {
+                        args.desktop || cfg.install.desktop_integration
+                    };
+                    if want_desktop {
+                        desktop::ensure_desktop_files(&eff)?;
+                        println!("Desktop entry installed");
+                    }
+
+                    // Prune: préserver la nouvelle current + l'ancienne current
+                    let mut preserve: Vec<PathBuf> = Vec::new();
+                    if let Ok(cur) = std::fs::read_link(&eff.current_symlink) {
+                        preserve.push(cur);
+                    }
+                    if let Some(prev) = previous_current {
+                        preserve.push(prev);
+                    }
+                    prune::prune_old_versions_with_preserve(&eff.versions_dir, keep, &preserve)?;
+                    Ok(())
+                } else {
+                    bail!("--tar <FILE> is required for now. Network download will be added next.")
+                }
+            }
+
+            Commands::Use(args) => {
+                if args.dry_run {
+                    let target = eff.versions_dir.join(&args.version);
+                    println!("[dry-run] would switch current -> {}", target.display());
+                    return Ok(());
+                }
+                switch_to_version(&eff, &args.version)?;
+                // le shim pointe déjà vers 'current', donc rien à régénérer
+                Ok(())
+            }
+
+            Commands::Update(args) => {
+                use directories::ProjectDirs;
+                use semver::Version;
+                use std::path::PathBuf;
+
+                // 1) Local version
+                let local = version::detect_local_version(&eff)?;
+
+                // 2) Remote via API (version + url)
+                let latest = crate::remote::latest_stable_linux_x64(None)?;
+                let latest_ver = Version::parse(&latest.version).map_err(|e| {
+                    anyhow::anyhow!("cannot parse remote version {}: {}", latest.version, e)
+                })?;
+
+                // 3) Compare
+                if let Some(local_s) = &local {
+                    if let Ok(local_ver) = Version::parse(local_s) {
+                        if local_ver >= latest_ver {
+                            println!(
+                                "Already up to date (local: {}, latest: {}).",
+                                local_ver, latest_ver
+                            );
+                            return Ok(());
+                        }
+                    }
+                }
+
+                // 4) Dry-run?
+                if args.dry_run {
+                    println!("[dry-run] local : {}", local.as_deref().unwrap_or("<none>"));
+                    println!("[dry-run] latest: {}", latest_ver);
+                    println!("[dry-run] url   : {}", latest.url);
+                    return Ok(());
+                }
+
+                // 5) Download to cache
+                let proj = ProjectDirs::from("dev", "Windman", "windman")
+                    .ok_or_else(|| anyhow::anyhow!("cannot determine project dirs"))?;
+                let dl_dir = proj.cache_dir().join("downloads").join(&latest.version);
+                std::fs::create_dir_all(&dl_dir)?;
+                let filename = latest
+                    .url
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or("windsurf-linux-x64.tar.gz");
+                let tar_path: PathBuf = dl_dir.join(filename);
+
+                crate::download::download_to_file_with_timeout(&latest.url, &tar_path, None)
+                    .map_err(|e| anyhow::anyhow!("downloading {}: {}", latest.url, e))?;
+                println!("Downloaded {}", tar_path.display());
+
+                // 6) Install (avec capture de l'ancienne current pour prune)
+                let previous_current: Option<PathBuf> =
+                    std::fs::read_link(&eff.current_symlink).ok();
+
+                let ver = install::install_from_tar(tar_path.to_string_lossy().as_ref(), &eff)?;
+                println!("Installed Windsurf {} to {:?}", ver, eff.prefix_dir);
+
+                // 7) Desktop
+                let want_desktop = if args.no_desktop {
+                    false
+                } else {
+                    args.desktop || cfg.install.desktop_integration
+                };
+                if want_desktop {
+                    desktop::ensure_desktop_files(&eff)?;
+                    println!("Desktop entry installed");
+                }
+
+                // 8) Prune: préserver la nouvelle current + l'ancienne current
+                let mut preserve: Vec<PathBuf> = Vec::new();
+                if let Ok(cur) = std::fs::read_link(&eff.current_symlink) {
+                    preserve.push(cur);
+                }
+                if let Some(prev) = previous_current {
+                    preserve.push(prev);
+                }
+                prune::prune_old_versions_with_preserve(
+                    &eff.versions_dir,
+                    cfg.install.keep,
+                    &preserve,
+                )?;
+                Ok(())
+            }
+
+            Commands::Status => {
+                let local = version::detect_local_version(&eff)?;
+                println!("Install prefix : {}", eff.prefix_dir.display());
+                println!("Current link   : {}", eff.current_symlink.display());
+                println!("Shim           : {}", eff.bin_shim.display());
+                match local {
+                    Some(v) => println!("Local version  : {}", v),
+                    None => println!("Local version  : <not installed>"),
+                }
+                Ok(())
+            }
+
+            Commands::Where => {
+                println!("prefix : {}", eff.prefix_dir.display());
+                println!("current: {}", eff.current_symlink.display());
+                println!("shim   : {}", eff.bin_shim.display());
+                Ok(())
+            }
+
+            Commands::List => {
+                let entries = collect_installed(&eff);
+
+                if entries.is_empty() {
+                    println!(
+                        "No installed versions found in {}.",
+                        eff.versions_dir.display()
+                    );
+                } else {
+                    println!("Installed versions in {}:", eff.versions_dir.display());
+                    for (name, is_current) in entries {
+                        if is_current {
+                            println!("* {}   (current)", name);
+                        } else {
+                            println!("  {}", name);
+                        }
+                    }
+                }
+                Ok(())
+            }
+
+            Commands::Changelog => {
+                println!("Changelog delta not implemented yet (coming next).");
+                Ok(())
+            }
+
+            Commands::Uninstall { purge } => {
+                install::uninstall_all(&eff, *purge)?;
+                println!("Windman userland install removed.");
+                Ok(())
+            }
+
+            Commands::Rollback => {
+                install::rollback(&eff)?;
+                Ok(())
+            }
+
+            Commands::Config(sub) => match sub {
+                ConfigCmd::Init => {
+                    cfg.save_if_missing(&cfg_paths)?;
+                    println!("Config written to {}", cfg_paths.config_display());
+                    Ok(())
+                }
+                ConfigCmd::Show => {
+                    println!("{}", toml::to_string_pretty(&cfg)?);
+                    Ok(())
+                }
+            },
+
+            Commands::DevLatest(args) => {
+                use anyhow::Context;
+                let timeout = args.timeout;
+
+                if let Some(path) = &args.dump_html {
+                    let html = crate::remote::fetch_releases_html(timeout)?;
+                    std::fs::write(path, &html).with_context(|| format!("writing {}", path))?;
+                    println!("Dumped releases HTML to {}", path);
+                    return Ok(());
+                }
+
+                let info = crate::remote::latest_stable_linux_x64(timeout)?;
+                println!("latest.version = {}", info.version);
+                println!("latest.url     = {}", info.url);
+                Ok(())
+            }
+
+            Commands::DevDownload(args) => {
+                use std::path::Path;
+                crate::download::download_to_file_with_timeout(
+                    &args.url,
+                    Path::new(&args.out),
+                    args.timeout,
+                )?;
+                println!("Downloaded to {}", args.out);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests_list_collect {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn collects_and_marks_current() {
+        let tmp = tempdir().unwrap();
+        let eff = crate::paths::EffectivePaths {
+            prefix_dir: tmp.path().to_path_buf(),
+            versions_dir: tmp.path().join("versions"),
+            current_symlink: tmp.path().join("current"),
+            bin_dir: tmp.path().join("bin"),
+            bin_shim: tmp.path().join("bin/windsurf"),
+            desktop_file: tmp.path().join("share/applications/windsurf.desktop"),
+            icons_dir: tmp.path().join("share/icons"),
+        };
+        fs::create_dir_all(&eff.versions_dir.join("1.12.9")).unwrap();
+        fs::create_dir_all(&eff.versions_dir.join("1.12.11")).unwrap();
+        std::os::unix::fs::symlink(&eff.versions_dir.join("1.12.9"), &eff.current_symlink).unwrap();
+
+        let got = collect_installed(&eff);
+        // tri semver desc => 1.12.11, 1.12.9
+        assert_eq!(got[0].0, "1.12.11");
+        assert_eq!(got[1].0, "1.12.9");
+        assert!(got.iter().find(|(n, _)| n == "1.12.9").unwrap().1);
+    }
+}
+
+#[cfg(test)]
+mod tests_use_switch {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn switches_current_symlink_to_requested_version() {
+        let tmp = tempdir().unwrap();
+        let eff = crate::paths::EffectivePaths {
+            prefix_dir: tmp.path().to_path_buf(),
+            versions_dir: tmp.path().join("versions"),
+            current_symlink: tmp.path().join("current"),
+            bin_dir: tmp.path().join("bin"),
+            bin_shim: tmp.path().join("bin/windsurf"),
+            desktop_file: tmp.path().join("share/applications/windsurf.desktop"),
+            icons_dir: tmp.path().join("share/icons"),
+        };
+        fs::create_dir_all(eff.versions_dir.join("1.12.10")).unwrap();
+        fs::create_dir_all(eff.versions_dir.join("1.12.11")).unwrap();
+
+        // current -> 1.12.10
+        std::os::unix::fs::symlink(eff.versions_dir.join("1.12.10"), &eff.current_symlink).unwrap();
+
+        // switch
+        switch_to_version(&eff, "1.12.11").unwrap();
+        let cur = fs::read_link(&eff.current_symlink).unwrap();
+        assert_eq!(cur.file_name().unwrap().to_string_lossy(), "1.12.11");
+    }
+
+    #[test]
+    fn errors_if_version_missing_with_available_list() {
+        let tmp = tempdir().unwrap();
+        let eff = crate::paths::EffectivePaths {
+            prefix_dir: tmp.path().to_path_buf(),
+            versions_dir: tmp.path().join("versions"),
+            current_symlink: tmp.path().join("current"),
+            bin_dir: tmp.path().join("bin"),
+            bin_shim: tmp.path().join("bin/windsurf"),
+            desktop_file: tmp.path().join("share/applications/windsurf.desktop"),
+            icons_dir: tmp.path().join("share/icons"),
+        };
+        fs::create_dir_all(eff.versions_dir.join("1.12.11")).unwrap();
+
+        let err = switch_to_version(&eff, "1.12.9").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not found"));
+        assert!(msg.contains("1.12.11"));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,129 @@
+use anyhow::{Context, Result};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct ConfigPaths {
+    pub dir: PathBuf,
+    pub file: PathBuf,
+}
+
+impl ConfigPaths {
+    pub fn from_override(override_path: Option<&str>) -> Self {
+        if let Some(p) = override_path {
+            let file = shellexpand::tilde(p).into_owned();
+            let file = PathBuf::from(file);
+            let dir = file.parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+            return Self { dir, file };
+        }
+        let proj = ProjectDirs::from("dev", "Windman", "windman")
+            .expect("cannot determine config dir");
+        let dir = proj.config_dir().to_path_buf();
+        let file = dir.join("windman.toml");
+        Self { dir, file }
+    }
+
+    pub fn config_display(&self) -> String {
+        self.file.display().to_string()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallConfig {
+    /// Default userland prefix for versioned installs
+    pub prefix_dir: String, // e.g. "~/.local/opt/windsurf"
+    /// Where the shim is written
+    pub bin_dir: String,    // e.g. "~/.local/bin"
+    /// Only "stable" for now
+    pub channel: String,
+    /// Keep N newest versions (prune policy)
+    pub keep: usize,
+    /// Create/update desktop integration by default
+    pub desktop_integration: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NetworkConfig {
+    /// Reserved for future proxy support
+    pub proxy_enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    pub install: InstallConfig,
+    #[serde(default)]
+    pub changelog: ChangelogConfig,
+    pub network: NetworkConfig,
+    // NOTE: telemetry removed (standalone, no tracking).
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ChangelogConfig {
+    // reserved for future (e.g., show delta)
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            install: InstallConfig {
+                prefix_dir: "~/.local/opt/windsurf".to_string(),
+                bin_dir: "~/.local/bin".to_string(),
+                channel: "stable".to_string(),
+                keep: 2,
+                desktop_integration: true,
+            },
+            changelog: ChangelogConfig::default(),
+            network: NetworkConfig {
+                proxy_enabled: false,
+            },
+        }
+    }
+}
+
+impl Config {
+    pub fn load_or_default(paths: &ConfigPaths) -> Result<Self> {
+        if paths.file.exists() {
+            let s = fs::read_to_string(&paths.file)
+                .with_context(|| format!("reading {}", paths.config_display()))?;
+            // Unknown fields (e.g., legacy [telemetry]) are ignored by default.
+            let cfg: Config = toml::from_str(&s)
+                .with_context(|| format!("parsing {}", paths.config_display()))?;
+            Ok(cfg)
+        } else {
+            Ok(Self::default())
+        }
+    }
+
+    pub fn save_if_missing(&self, paths: &ConfigPaths) -> Result<()> {
+        if !paths.dir.exists() {
+            fs::create_dir_all(&paths.dir)
+                .with_context(|| format!("creating {}", paths.dir.display()))?;
+        }
+        if !paths.file.exists() {
+            let mut out = String::new();
+            out.push_str("[install]\n");
+            out.push_str(&format!("prefix_dir = \"{}\"\n", self.install.prefix_dir));
+            out.push_str(&format!("bin_dir = \"{}\"\n", self.install.bin_dir));
+            out.push_str(&format!("channel = \"{}\"\n", self.install.channel));
+            out.push_str(&format!("keep = {}\n", self.install.keep));
+            out.push_str(&format!(
+                "desktop_integration = {}\n\n",
+                self.install.desktop_integration
+            ));
+
+            out.push_str("[changelog]\n\n");
+
+            out.push_str("[network]\n");
+            out.push_str(&format!(
+                "proxy_enabled = {}\n",
+                self.network.proxy_enabled
+            ));
+
+            fs::write(&paths.file, out)
+                .with_context(|| format!("writing {}", paths.config_display()))?;
+        }
+        Ok(())
+    }
+}

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -1,0 +1,67 @@
+use crate::paths::EffectivePaths;
+use anyhow::Result;
+use std::fs;
+
+pub fn ensure_desktop_files(eff: &EffectivePaths) -> Result<()> {
+    if !eff.icons_dir.exists() {
+        fs::create_dir_all(&eff.icons_dir)?;
+    }
+
+    // icon is optional; users may add their own. We just ensure the dir exists.
+    // If you want to install an icon file, write it to eff.icons_dir.join("windsurf.png").
+
+    let desktop_dir = eff.desktop_file.parent().unwrap();
+    if !desktop_dir.exists() {
+        fs::create_dir_all(desktop_dir)?;
+    }
+
+    let exec_path = eff.current_symlink.join("Windsurf");
+    let content = format!(
+        "[Desktop Entry]\nName=Windsurf\nComment=AI IDE by Codeium\nExec={} %U\nTerminal=false\nType=Application\nIcon=windsurf\nCategories=Development;IDE;\nStartupWMClass=Windsurf\n",
+        exec_path.display()
+    );
+    fs::write(&eff.desktop_file, content)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::paths::EffectivePaths;
+    use std::{fs, os::unix::fs::symlink};
+    use tempfile::tempdir;
+
+    #[test]
+    fn ensure_desktop_files_writes_entry_pointing_to_current() {
+        let td = tempdir().unwrap();
+        let base = td.path();
+
+        // Fake version dir with a fake "Windsurf" executable
+        let vdir = base.join("1.2.3");
+        fs::create_dir_all(&vdir).unwrap();
+        fs::write(vdir.join("Windsurf"), b"#!/bin/sh\necho ws\n").unwrap();
+
+        // current -> vdir
+        let current = base.join("current");
+        symlink(&vdir, &current).unwrap();
+
+        // EffectivePaths au sein du tempdir
+        let eff = EffectivePaths {
+            prefix_dir: base.to_path_buf(),
+            versions_dir: base.to_path_buf(),
+            current_symlink: current.clone(),
+            bin_dir: base.join("bin"),
+            bin_shim: base.join("bin/windsurf"),
+            desktop_file: base.join("share/applications/windsurf.desktop"),
+            icons_dir: base.join("share/icons/hicolor/512x512/apps"),
+        };
+
+        super::ensure_desktop_files(&eff).unwrap();
+        let desktop = fs::read_to_string(&eff.desktop_file).unwrap();
+        assert!(desktop.contains("Name=Windsurf"));
+        assert!(desktop.contains("Exec="));
+        assert!(desktop.contains("Icon=windsurf"));
+        // L'Exec doit pointer vers current/Windsurf
+        let exec_line = desktop.lines().find(|l| l.starts_with("Exec=")).unwrap();
+        assert!(exec_line.contains("current/Windsurf"));
+    }
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,0 +1,108 @@
+use anyhow::{Context, Result};
+use indicatif::{ProgressBar, ProgressStyle};
+use reqwest::blocking::Client;
+use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
+use std::{
+    fs::{self, File},
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// Build a blocking reqwest client with default headers and a timeout.
+fn build_client(timeout_secs: u64) -> Result<Client> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_static("Windman/0.1 (+https://github.com/your-org/windman)"),
+    );
+
+    let client = Client::builder()
+        .default_headers(headers)
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+        .context("building HTTP client")?;
+    Ok(client)
+}
+
+/// Download `url` to `dest`, with optional timeout override (in seconds).
+/// Writes atomically: to `dest.part` then renames to `dest` at the end.
+pub fn download_to_file_with_timeout(
+    url: &str,
+    dest: &Path,
+    timeout_override: Option<u64>,
+) -> Result<()> {
+    let timeout = timeout_override.unwrap_or(DEFAULT_TIMEOUT_SECS);
+
+    // Ensure parent directory exists
+    let parent: PathBuf = dest
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    if !parent.exists() {
+        fs::create_dir_all(&parent)
+            .with_context(|| format!("creating parent directory {}", parent.display()))?;
+    }
+
+    // Temp file in same directory for atomic rename at the end
+    let temp_path = dest.with_extension("part");
+    let client = build_client(timeout)?;
+
+    let resp = client
+        .get(url)
+        .send()
+        .with_context(|| format!("GET {}", url))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        anyhow::bail!("unexpected status {} for {}", status, url);
+    }
+
+    // Progress (bar when Content-Length is known, spinner otherwise)
+    let len = resp.content_length();
+    let pb = match len {
+        Some(total) => {
+            let pb = ProgressBar::new(total);
+            pb.set_style(
+                ProgressStyle::with_template("{bar} {bytes}/{total_bytes} {eta}")?
+                    .progress_chars("#>-"),
+            );
+            pb
+        }
+        None => {
+            let pb = ProgressBar::new_spinner();
+            pb.set_style(ProgressStyle::with_template(
+                "{spinner} {bytes} downloaded",
+            )?);
+            pb.enable_steady_tick(Duration::from_millis(120));
+            pb
+        }
+    };
+
+    let mut reader = resp;
+    let mut out = File::create(&temp_path)
+        .with_context(|| format!("creating temp file {}", temp_path.display()))?;
+
+    let mut buf = [0u8; 64 * 1024];
+    let mut downloaded: u64 = 0;
+
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        out.write_all(&buf[..n])?;
+        downloaded += n as u64;
+        pb.set_position(downloaded);
+    }
+
+    pb.finish_and_clear();
+
+    // Atomic rename to final destination
+    fs::rename(&temp_path, dest)
+        .with_context(|| format!("renaming {} -> {}", temp_path.display(), dest.display()))?;
+
+    Ok(())
+}

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,0 +1,243 @@
+use anyhow::{bail, Context, Result};
+use flate2::read::GzDecoder;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use tar::Archive;
+
+use crate::paths::EffectivePaths;
+use crate::util::{atomic_symlink_switch, timestamp_version, write_shim};
+/// Install from a .tar.gz path. Returns the resolved version string used.
+pub fn install_from_tar(tar_path: &str, eff: &EffectivePaths) -> Result<String> {
+    fs::create_dir_all(&eff.versions_dir)
+        .with_context(|| format!("creating {}", eff.versions_dir.display()))?;
+
+    // Staging dir (atomic move later)
+    let staging = eff
+        .versions_dir
+        .join(format!(".staging-{}", timestamp_version()));
+    if staging.exists() {
+        fs::remove_dir_all(&staging).ok();
+    }
+    fs::create_dir_all(&staging)?;
+
+    // Extract tar.gz
+    extract_tar_to_dir(tar_path, &staging)?;
+
+    // mémoriser la current avant bascule (si elle existe)
+    let _previous_current = std::fs::read_link(&eff.current_symlink).ok();
+
+    // Determine version:
+    // 1) from tar filename
+    let ver_from_filename = extract_version_from_filename(tar_path);
+
+    // 2) from product.json if present
+    let ver_from_product = detect_version_from_product_json(&staging).ok();
+
+    // 3) choose dir name
+    let version = ver_from_filename
+        .or(ver_from_product)
+        .unwrap_or_else(timestamp_version);
+
+    let final_dir = eff.versions_dir.join(&version);
+
+    // If target exists already, remove it before rename (overwrite)
+    if final_dir.exists() {
+        fs::remove_dir_all(&final_dir)
+            .with_context(|| format!("removing pre-existing {}", final_dir.display()))?;
+    }
+
+    // Move staging -> final
+    fs::rename(&staging, &final_dir)
+        .with_context(|| format!("moving {} -> {}", staging.display(), final_dir.display()))?;
+
+    // Update 'current' symlink atomically
+    atomic_symlink_switch(&final_dir, &eff.current_symlink)?;
+
+    // Ensure bin dir exists and write shim
+    fs::create_dir_all(&eff.bin_dir)?;
+    write_shim(&eff.bin_shim, &eff.current_symlink)?;
+
+    Ok(version)
+}
+
+pub fn rollback(eff: &EffectivePaths) -> Result<()> {
+    use std::fs;
+    // List versions
+    let mut dirs = list_version_dirs(&eff.versions_dir)?;
+    if dirs.len() < 2 {
+        bail!("no previous version to roll back to");
+    }
+    // current target
+    let cur_target = fs::read_link(&eff.current_symlink)
+        .with_context(|| format!("reading {}", eff.current_symlink.display()))?;
+    // Remove current from list
+    dirs.retain(|p| p != &cur_target);
+    // Pick the most recent by mtime
+    dirs.sort_by_key(|p| fs::metadata(p).and_then(|m| m.modified()).ok());
+    let prev = dirs.pop().unwrap();
+    atomic_symlink_switch(&prev, &eff.current_symlink)?;
+    println!(
+        "Rolled back to {}",
+        prev.file_name().unwrap().to_string_lossy()
+    );
+    Ok(())
+}
+
+pub fn uninstall_all(eff: &EffectivePaths, purge: bool) -> Result<()> {
+    // Remove symlink & shim
+    let _ = fs::remove_file(&eff.current_symlink);
+    let _ = fs::remove_file(&eff.bin_shim);
+
+    // Remove versions dir
+    if eff.versions_dir.exists() {
+        fs::remove_dir_all(&eff.versions_dir)?;
+    }
+
+    if purge {
+        // Remove desktop files, icons etc. (best-effort)
+        let _ = fs::remove_file(&eff.desktop_file);
+        if eff.icons_dir.exists() {
+            let _ = fs::remove_dir_all(&eff.icons_dir);
+        }
+    }
+    Ok(())
+}
+
+// ---------------- helpers ----------------
+
+fn extract_tar_to_dir(tar_path: &str, dest: &Path) -> Result<()> {
+    let file = File::open(tar_path).with_context(|| format!("opening {}", tar_path))?;
+    let dec = GzDecoder::new(file);
+    let mut ar = Archive::new(dec);
+    ar.unpack(dest)
+        .with_context(|| format!("extracting to {}", dest.display()))?;
+    Ok(())
+}
+
+fn list_version_dirs(base: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    if base.exists() {
+        for ent in fs::read_dir(base)? {
+            let ent = ent?;
+            let p = ent.path();
+            if p.file_name().map(|n| n == "current").unwrap_or(false) {
+                continue;
+            }
+            if p.is_dir() {
+                out.push(p);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn extract_version_from_filename(path: &str) -> Option<String> {
+    let name = std::path::Path::new(path).file_name()?.to_string_lossy();
+    let re = regex::Regex::new(r"(\d+\.\d+\.\d+)").ok()?;
+    let caps = re.captures(&name)?;
+    Some(caps.get(1)?.as_str().to_string())
+}
+
+fn detect_version_from_product_json(extracted_root: &Path) -> Result<String> {
+    // Find product.json under **/resources/app/product.json (common layout)
+    // We'll scan one level or two deep to be safe.
+    let mut candidate: Option<PathBuf> = None;
+
+    // Typical layout: extracted_root/<some-root>/resources/app/product.json
+    for entry in walkdir::WalkDir::new(extracted_root)
+        .min_depth(1)
+        .max_depth(4)
+    {
+        let entry = entry?;
+        let p = entry.path();
+        if p.file_name().map(|n| n == "product.json").unwrap_or(false) {
+            candidate = Some(p.to_path_buf());
+            break;
+        }
+    }
+
+    let p = candidate.ok_or_else(|| anyhow::anyhow!("product.json not found"))?;
+    let data = std::fs::read_to_string(&p).with_context(|| format!("reading {}", p.display()))?;
+    let v = parse_windsurf_version_from_product(&data)
+        .ok_or_else(|| anyhow::anyhow!("windsurfVersion not found in product.json"))?;
+    Ok(v)
+}
+
+fn parse_windsurf_version_from_product(s: &str) -> Option<String> {
+    let v = json_extract_field(s, "windsurfVersion")?;
+    Some(v)
+}
+
+/// extract a top-level string field from a JSON blob without full serde (lenient)
+fn json_extract_field(s: &str, field: &str) -> Option<String> {
+    // very lenient regex just to fish out "field":"value"
+    let re = regex::Regex::new(&format!(r#""{}\s*"\s*:\s*"(.*?)""#, regex::escape(field))).ok()?;
+    let caps = re.captures(s)?;
+    Some(caps.get(1)?.as_str().to_string())
+}
+
+#[cfg(test)]
+mod tests_install_from_tar_names_dir_by_version {
+    use super::*;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    // Crée un tar.gz minimal: Windsurf/bin/windsurf + Windsurf/resources/app/product.json
+    fn make_fake_windsurf_tar(path: &Path, version: &str) {
+        let tarfile = File::create(path).unwrap();
+        let enc = flate2::write::GzEncoder::new(tarfile, flate2::Compression::default());
+        let mut builder = tar::Builder::new(enc);
+
+        let bin_path = "Windsurf/bin/windsurf";
+        let prod_path = "Windsurf/resources/app/product.json";
+
+        let mut bin_hdr = tar::Header::new_gnu();
+        bin_hdr.set_path(bin_path).unwrap();
+        bin_hdr.set_mode(0o755);
+        bin_hdr.set_size(2);
+        bin_hdr.set_cksum();
+        builder.append(&bin_hdr, &b"#!"[..]).unwrap();
+
+        let prod_json = format!(r#"{{ "windsurfVersion":"{}" }}"#, version);
+        let mut prod_hdr = tar::Header::new_gnu();
+        prod_hdr.set_path(prod_path).unwrap();
+        prod_hdr.set_mode(0o644);
+        prod_hdr.set_size(prod_json.len() as u64);
+        prod_hdr.set_cksum();
+        builder.append(&prod_hdr, prod_json.as_bytes()).unwrap();
+
+        builder.finish().unwrap();
+    }
+
+    #[test]
+    fn install_uses_semver_dir_and_updates_current() {
+        let tmp = tempdir().unwrap();
+        let prefix = tmp.path().to_path_buf();
+
+        // EffectivePaths minimal vers tmp
+        let eff = crate::paths::EffectivePaths {
+            prefix_dir: prefix.clone(),
+            versions_dir: prefix.join("versions"),
+            current_symlink: prefix.join("current"),
+            bin_dir: prefix.join("bin"),
+            bin_shim: prefix.join("bin/windsurf"),
+            desktop_file: prefix.join("share/applications/windsurf.desktop"),
+            icons_dir: prefix.join("share/icons"),
+        };
+
+        std::fs::create_dir_all(&eff.versions_dir).unwrap();
+
+        let tar_path = tmp.path().join("Windsurf-linux-x64-2.3.4.tar.gz");
+        make_fake_windsurf_tar(&tar_path, "2.3.4");
+
+        let ver = super::install_from_tar(tar_path.to_string_lossy().as_ref(), &eff).unwrap();
+        assert_eq!(ver, "2.3.4");
+
+        // current -> .../2.3.4
+        let cur = std::fs::read_link(&eff.current_symlink).unwrap();
+        assert_eq!(cur.file_name().unwrap().to_string_lossy(), "2.3.4");
+
+        // Shim créé
+        assert!(eff.bin_shim.is_file());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+
+mod cli;
+mod config;
+mod desktop;
+mod download;
+mod install;
+mod paths;
+mod prune;
+mod remote;
+mod util;
+mod version;
+
+use cli::Cli;
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    cli.run()
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,63 @@
+use anyhow::Result;
+use directories::BaseDirs;
+use shellexpand::tilde;
+use std::path::{PathBuf};
+
+use crate::config::Config;
+
+/// All resolved (expanded) paths Windman uses at runtime.
+#[derive(Debug, Clone)]
+pub struct EffectivePaths {
+    /// Versioned installs live here (e.g. ~/.local/opt/windsurf/1.12.11)
+    pub prefix_dir: PathBuf,
+    /// Alias to the same place where version dirs live (kept for clarity/tests)
+    pub versions_dir: PathBuf,
+    /// Symlink pointing to the active version dir (e.g. ~/.local/opt/windsurf/current)
+    pub current_symlink: PathBuf,
+    /// Where the shim script is written (dir only, e.g. ~/.local/bin)
+    pub bin_dir: PathBuf,
+    /// Full path to the shim (e.g. ~/.local/bin/windsurf)
+    pub bin_shim: PathBuf,
+    /// Desktop entry path (e.g. ~/.local/share/applications/windsurf.desktop)
+    pub desktop_file: PathBuf,
+    /// Icons base dir (e.g. ~/.local/share/icons)
+    pub icons_dir: PathBuf,
+}
+
+/// Expand a path that may contain ~
+fn expand(p: &str) -> PathBuf {
+    PathBuf::from(tilde(p).into_owned())
+}
+
+/// Compute effective paths from config (expands ~, fills XDG locations).
+pub fn resolve_paths(cfg: &Config) -> Result<EffectivePaths> {
+    let prefix_dir = expand(&cfg.install.prefix_dir);
+    let versions_dir = prefix_dir.clone();
+    let current_symlink = prefix_dir.join("current");
+
+    let bin_dir = expand(&cfg.install.bin_dir);
+    let bin_shim = bin_dir.join("windsurf");
+
+    // XDG data (for desktop file + icons)
+    let base = BaseDirs::new();
+    // Fallback to ~/.local/share if XDG can't be resolved (very rare)
+    let data_dir = base
+        .map(|b| b.data_local_dir().to_path_buf())
+        .unwrap_or_else(|| {
+            let home = std::env::var_os("HOME").map(PathBuf::from).unwrap_or_else(|| PathBuf::from("~"));
+            home.join(".local/share")
+        });
+
+    let desktop_file = data_dir.join("applications/windsurf.desktop");
+    let icons_dir = data_dir.join("icons");
+
+    Ok(EffectivePaths {
+        prefix_dir,
+        versions_dir,
+        current_symlink,
+        bin_dir,
+        bin_shim,
+        desktop_file,
+        icons_dir,
+    })
+}

--- a/src/prune.rs
+++ b/src/prune.rs
@@ -1,0 +1,80 @@
+use anyhow::Result;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Prune with an explicit list of paths to preserve (e.g., current and previous_current).
+pub fn prune_old_versions_with_preserve(
+    versions_dir: &Path,
+    keep: usize,
+    preserve: &[PathBuf],
+) -> Result<()> {
+    // Collect version directories (skip "current")
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    if versions_dir.exists() {
+        for ent in fs::read_dir(versions_dir)? {
+            let ent = ent?;
+            let p = ent.path();
+            if p.file_name().map(|n| n == "current").unwrap_or(false) {
+                continue;
+            }
+            if p.is_dir() {
+                dirs.push(p);
+            }
+        }
+    }
+
+    // Sort by mtime desc (newest first)
+    dirs.sort_by_key(|p| fs::metadata(p).and_then(|m| m.modified()).ok());
+    dirs.reverse();
+
+    // Keep the N newest + any path listed in 'preserve'
+    let mut kept: Vec<PathBuf> = Vec::new();
+    for d in dirs {
+        let is_preserved = preserve.contains(&d);
+        if kept.len() < keep || is_preserved {
+            kept.push(d);
+        } else {
+            let _ = fs::remove_dir_all(&d);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    use std::{fs, thread, time::Duration};
+    use tempfile::tempdir;
+
+    #[test]
+    fn prune_keeps_n_newest_and_preserves_current() {
+        let td = tempdir().unwrap();
+        let versions_dir = td.path().to_path_buf();
+        fs::create_dir_all(&versions_dir).unwrap();
+
+        // Crée 3 versions avec mtime différents
+        let v1 = versions_dir.join("1.0.0");
+        fs::create_dir_all(&v1).unwrap();
+        thread::sleep(Duration::from_millis(10));
+
+        let v2 = versions_dir.join("1.0.1");
+        fs::create_dir_all(&v2).unwrap();
+        thread::sleep(Duration::from_millis(10));
+
+        let v3 = versions_dir.join("1.0.2");
+        fs::create_dir_all(&v3).unwrap();
+
+        // current -> v3
+        let current = versions_dir.join("current");
+        symlink(&v3, &current).unwrap();
+
+        // Préserver la current (v3) et garder N=2 versions au total
+        prune_old_versions_with_preserve(&versions_dir, 2, &[v3.clone()]).unwrap();
+
+        // v3 (current) doit exister; v2 doit rester (2 plus récentes); v1 supprimée
+        assert!(v3.exists(), "latest (and current) should remain");
+        assert!(v2.exists(), "second latest should remain");
+        assert!(!v1.exists(), "oldest should be pruned");
+    }
+}

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,0 +1,142 @@
+use anyhow::{anyhow, bail, Context, Result};
+use reqwest::blocking::Client;
+use reqwest::header::{ACCEPT, USER_AGENT};
+use serde::Deserialize;
+use std::{env, time::Duration};
+
+#[derive(Debug, Clone)]
+pub struct LatestInfo {
+    pub version: String,
+    pub url: String, // <- toujours présent en mode API
+}
+
+const DEFAULT_TIMEOUT_SECS: u64 = 15;
+const LINUX_X64_STABLE_LATEST: &str =
+    "https://windsurf-stable.codeium.com/api/update/linux-x64/stable/latest";
+const RELEASES_PAGE_URL: &str = "https://windsurf.com/editor/releases";
+
+fn build_client(timeout_secs: Option<u64>) -> Result<Client> {
+    let t = timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS);
+    Client::builder()
+        .timeout(Duration::from_secs(t))
+        .build()
+        .context("building reqwest Client")
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiLatest {
+    version: String,
+    url: String,
+}
+
+/// Essaie d’abord l’API officielle (surchargée par WINDMAN_LATEST_ENDPOINT si défini),
+/// qui renvoie {version, url}. C’est notre chemin standard.
+fn try_latest_via_api(client: &Client) -> Result<LatestInfo> {
+    let endpoint = env::var("WINDMAN_LATEST_ENDPOINT")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| LINUX_X64_STABLE_LATEST.to_string());
+
+    let resp = client
+        .get(&endpoint)
+        .header(USER_AGENT, "windman/0.1")
+        .header(ACCEPT, "application/json")
+        .send()
+        .with_context(|| format!("GET {}", endpoint))?;
+
+    if !resp.status().is_success() {
+        bail!("unexpected status {} for {}", resp.status(), endpoint);
+    }
+
+    let parsed: ApiLatest = resp.json().context("deserializing latest JSON")?;
+    if parsed.version.trim().is_empty() || parsed.url.trim().is_empty() {
+        bail!("latest API returned empty fields");
+    }
+    Ok(LatestInfo {
+        version: parsed.version,
+        url: parsed.url,
+    })
+}
+
+/// Secours : récupère le HTML et lit juste la version (pas l’URL).
+/// On s’en sert pour afficher une info utile si l’API est indispo.
+fn latest_version_from_releases_html(html: &str) -> Option<String> {
+    let re_h2 = regex::Regex::new(r"(?is)<h2[^>]*>\s*([0-9]+\.[0-9]+\.[0-9]+)\s*</h2>").ok()?;
+    let caps = re_h2.captures(html)?;
+    Some(caps.get(1)?.as_str().to_string())
+}
+
+pub fn fetch_releases_html(timeout_secs: Option<u64>) -> Result<String> {
+    let client = build_client(timeout_secs)?;
+    let resp = client
+        .get(RELEASES_PAGE_URL)
+        .header(USER_AGENT, "windman/0.1")
+        .header(ACCEPT, "text/html,*/*")
+        .send()
+        .with_context(|| format!("GET {}", RELEASES_PAGE_URL))?;
+    if !resp.status().is_success() {
+        bail!(
+            "unexpected status {} for {}",
+            resp.status(),
+            RELEASES_PAGE_URL
+        );
+    }
+    resp.text().context("reading releases HTML")
+}
+
+/// API publique : renvoie {version, url} via l’API. Si l’API tombe,
+/// on tente d’afficher la version via HTML puis on échoue proprement.
+pub fn latest_stable_linux_x64(timeout_secs: Option<u64>) -> Result<LatestInfo> {
+    let client = build_client(timeout_secs)?;
+
+    match try_latest_via_api(&client) {
+        Ok(mut info) => {
+            // Si la "version" n'est pas clairement un semver, on tente de l'extraire depuis l'URL.
+            let re = regex::Regex::new(r"(\d+\.\d+\.\d+)").unwrap();
+            let looks_like_semver = re.is_match(&info.version);
+            if !looks_like_semver {
+                if let Some(cap) = re.captures(&info.url) {
+                    info.version = cap.get(1).unwrap().as_str().to_string();
+                }
+            }
+            Ok(info)
+        }
+        Err(api_err) => {
+            // fallback “informative” : on trouve au moins la version HTML pour aider au debug
+            if let Ok(html) = fetch_releases_html(timeout_secs) {
+                if let Some(ver) = latest_version_from_releases_html(&html) {
+                    return Err(anyhow!(
+                        "failed to fetch latest JSON ({}), but releases page shows version {}.\n\
+                         Please try again later or override endpoint via WINDMAN_LATEST_ENDPOINT.",
+                        api_err,
+                        ver
+                    ));
+                }
+            }
+            Err(anyhow!("failed to fetch latest JSON: {}", api_err))
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn semver_from_string(s: &str) -> Option<String> {
+    let re = regex::Regex::new(r"(\d+\.\d+\.\d+)").ok()?;
+    re.captures(s)
+        .map(|c| c.get(1).unwrap().as_str().to_string())
+}
+#[cfg(test)]
+mod tests_semver_pick {
+    use super::*;
+
+    #[test]
+    fn picks_semver_from_url() {
+        let url = "https://windsurf-stable.codeiumdata.com/linux-x64/stable/abcd/Windsurf-linux-x64-1.12.11.tar.gz";
+        assert_eq!(semver_from_string(url).as_deref(), Some("1.12.11"));
+    }
+
+    #[test]
+    fn picks_semver_from_text() {
+        let s = "latest = 0.9.4 (build 42)";
+        assert_eq!(semver_from_string(s).as_deref(), Some("0.9.4"));
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,139 @@
+use anyhow::{Context, Result};
+use std::{fs, os::unix::fs::symlink, path::Path};
+use std::{io::Write, os::unix::fs::PermissionsExt};
+
+pub fn timestamp_version() -> String {
+    let t = chrono::Utc::now();
+    t.format("%Y%m%d%H%M%S").to_string()
+}
+
+pub fn atomic_symlink_switch(target: &Path, link: &Path) -> Result<()> {
+    let parent = link.parent().unwrap();
+    if !parent.exists() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = parent.join(format!(".tmp-{}", std::process::id()));
+    if tmp.exists() {
+        let _ = fs::remove_file(&tmp);
+    }
+    symlink(target, &tmp).context("creating temp symlink")?;
+    if link.exists() {
+        fs::remove_file(link).ok();
+    }
+    fs::rename(&tmp, link).context("renaming temp symlink into place")?;
+    Ok(())
+}
+
+pub fn write_shim(shim_path: &Path, current_symlink: &Path) -> Result<()> {
+    let current_str = current_symlink.display().to_string();
+
+    let script = format!(
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+CURRENT_LINK="{current}"
+ROOT="$(readlink -f "$CURRENT_LINK")"
+exe="$ROOT/Windsurf/bin/windsurf"
+if [ -x "$exe" ]; then
+  exec "$exe" "$@"
+fi
+# very small fallback
+if [ -x "$ROOT/windsurf" ]; then
+  exec "$ROOT/windsurf" "$@"
+fi
+echo "windman: could not locate Windsurf executable at: $exe" >&2
+exit 127
+"#,
+        current = current_str
+    );
+
+    if let Some(dir) = shim_path.parent() {
+        fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    }
+    let mut f =
+        fs::File::create(shim_path).with_context(|| format!("creating {}", shim_path.display()))?;
+    f.write_all(script.as_bytes())
+        .with_context(|| format!("writing {}", shim_path.display()))?;
+    drop(f);
+
+    let mut perms = fs::metadata(shim_path)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(shim_path, perms)?;
+    Ok(())
+}
+
+/// Best-effort extraction of a version-like name from folder path
+#[cfg(test)]
+pub fn guess_version_from_folder(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy();
+    // naive: pick first token that looks like digits and dots
+    for chunk in name.split(|c: char| !c.is_ascii_alphanumeric() && c != '.') {
+        if chunk.chars().all(|c| c.is_ascii_digit() || c == '.') && chunk.contains('.') {
+            return Some(chunk.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
+
+    #[test]
+    fn guess_version_from_folder_extracts_semverish() {
+        let p = Path::new("/tmp/Windsurf-1.12.9-linux-x64");
+        assert_eq!(guess_version_from_folder(p).as_deref(), Some("1.12.9"));
+
+        let p = Path::new("/tmp/ws-20240922");
+        assert!(guess_version_from_folder(p).is_none());
+    }
+
+    #[test]
+    fn timestamp_version_has_expected_length() {
+        let v = timestamp_version();
+        // e.g. "20250927153322" -> 14 chars
+        assert_eq!(v.len(), 14);
+        assert!(v.chars().all(|c| c.is_ascii_digit()));
+    }
+
+    #[test]
+    fn atomic_symlink_switch_works() {
+        let td = tempdir().unwrap();
+        let base = td.path();
+        let v1 = base.join("1.0.0");
+        fs::create_dir_all(&v1).unwrap();
+        let v2 = base.join("1.0.1");
+        fs::create_dir_all(&v2).unwrap();
+        let link = base.join("current");
+
+        // switch -> v1
+        atomic_symlink_switch(&v1, &link).unwrap();
+        assert_eq!(fs::read_link(&link).unwrap(), v1);
+
+        // switch -> v2
+        atomic_symlink_switch(&v2, &link).unwrap();
+        assert_eq!(fs::read_link(&link).unwrap(), v2);
+    }
+
+    #[test]
+    fn write_shim_creates_executable_script() {
+        let td = tempdir().unwrap();
+        let shim = td.path().join("bin").join("windsurf");
+        let exec = td.path().join("Windsurf");
+        fs::create_dir_all(shim.parent().unwrap()).unwrap();
+        fs::write(&exec, b"#!/bin/sh\necho hi\n").unwrap();
+
+        write_shim(&shim, &exec).unwrap();
+        let content = fs::read_to_string(&shim).unwrap();
+        assert!(content.contains(exec.to_string_lossy().as_ref()));
+
+        #[cfg(unix)]
+        {
+            let mode = fs::metadata(&shim).unwrap().permissions().mode();
+            assert!(mode & 0o111 != 0, "shim should be executable");
+        }
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,126 @@
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::{fs, path::PathBuf};
+
+use crate::paths::EffectivePaths;
+
+/// Detect the local Windsurf version by resolving the 'current' symlink
+/// and scanning for a 'product.json' (up to a few levels deep).
+/// Returns Some("x.y.z") or Ok(None) if not installed.
+pub fn detect_local_version(eff: &EffectivePaths) -> Result<Option<String>> {
+    // 1) Ensure the 'current' symlink exists
+    if !eff.current_symlink.exists() {
+        return Ok(None);
+    }
+
+    // 2) Resolve the symlink target (folder of the active install)
+    let current_target =
+        fs::read_link(&eff.current_symlink).unwrap_or_else(|_| eff.current_symlink.clone());
+
+    // 3) Search for product.json within the active folder
+    if let Some(product_path) = find_product_json(&current_target) {
+        let data = fs::read_to_string(&product_path)
+            .with_context(|| format!("reading {}", product_path.display()))?;
+
+        // Try JSON parse first
+        if let Ok(json) = serde_json::from_str::<Value>(&data) {
+            // Prefer "windsurfVersion", else "version"
+            if let Some(v) = json.get("windsurfVersion").and_then(|x| x.as_str()) {
+                return Ok(Some(v.to_string()));
+            }
+            if let Some(v) = json.get("version").and_then(|x| x.as_str()) {
+                return Ok(Some(v.to_string()));
+            }
+        }
+
+        // Fallback: regex fish-out if JSON had comments or odd format
+        if let Some(v) = regex_fish_version(&data) {
+            return Ok(Some(v));
+        }
+
+        // If product.json exists but we couldn't parse a version, treat as not installed
+        return Ok(None);
+    }
+
+    // No product.json found → not installed (or layout unexpected)
+    Ok(None)
+}
+
+/// Walk a few levels to find .../resources/app/product.json under current target.
+/// Typical paths:
+///   <root>/Windsurf/resources/app/product.json
+///   <root>/resources/app/product.json
+fn find_product_json(root: &PathBuf) -> Option<PathBuf> {
+    // Minimal scanning to avoid heavy WalkDir; we know common patterns.
+    let candidates = [
+        root.join("resources/app/product.json"),
+        root.join("Windsurf/resources/app/product.json"),
+        root.join("app/resources/product.json"), // just-in-case variants
+        root.join("resources/product.json"),
+    ];
+
+    for p in candidates {
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+
+    // As a last resort, do a shallow walk (depth ≤ 4)
+    // Requires walkdir in Cargo.toml (already present in your project)
+    for entry in walkdir::WalkDir::new(root).max_depth(4) {
+        let entry = entry.ok()?;
+        let p = entry.path();
+        if p.file_name().map(|n| n == "product.json").unwrap_or(false) && p.is_file() {
+            return Some(p.to_path_buf());
+        }
+    }
+
+    None
+}
+
+fn regex_fish_version(s: &str) -> Option<String> {
+    // look for "windsurfVersion":"x.y.z" or "version":"x.y.z"
+    let re = regex::Regex::new(r#""(?:windsurfVersion|version)"\s*:\s*"(\d+\.\d+\.\d+)""#).ok()?;
+    let caps = re.captures(s)?;
+    Some(caps.get(1)?.as_str().to_string())
+}
+
+#[cfg(test)]
+mod tests_detect_version_layout_linux {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detects_version_under_windsurf_resources_app() {
+        let tmp = tempdir().unwrap();
+        // Simule: <prefix>/versions/<ver>/Windsurf/resources/app/product.json
+        let root = tmp.path().join("versions");
+        let ver_dir = root.join("1.2.3");
+        let prod = ver_dir.join("Windsurf/resources/app");
+        fs::create_dir_all(&prod).unwrap();
+        fs::write(
+            prod.join("product.json"),
+            r#"{ "windsurfVersion":"1.2.3" }"#,
+        )
+        .unwrap();
+
+        // current -> <ver_dir>
+        let current = tmp.path().join("current");
+        std::os::unix::fs::symlink(&ver_dir, &current).unwrap();
+
+        // EffectivePaths minimal
+        let eff = crate::paths::EffectivePaths {
+            prefix_dir: tmp.path().to_path_buf(),
+            versions_dir: root.clone(),
+            current_symlink: current.clone(),
+            bin_dir: tmp.path().join("bin"),
+            bin_shim: tmp.path().join("bin/windsurf"),
+            desktop_file: tmp.path().join("share/applications/windsurf.desktop"),
+            icons_dir: tmp.path().join("share/icons"),
+        };
+
+        let v = detect_local_version(&eff).unwrap();
+        assert_eq!(v.as_deref(), Some("1.2.3"));
+    }
+}


### PR DESCRIPTION
## Summary

This PR delivers the first MVP of Windman, a standalone CLI to manage the Windsurf IDE on Linux.
It also introduces a full CI/CD pipeline, commitlint enforcement, and release automation.

## Changes

### Features

- Userland installation of Windsurf (default prefix: `~/.local/opt/windsurf`, shim: `~/.local/bin/windsurf`)
- Versioned installs with atomic `current` symlink
- `update` command: download latest stable release and install
- `install --tar` for offline/local testing
- `list` and `status` commands to inspect installed versions
- `use <version>` command to switch active version
- `rollback` to restore previous version
- `keep` policy to prune older versions safely
- Optional desktop integration (enabled by default, override with CLI)


## Tooling & CI/CD

- Added Taskfile.yml for reproducible build/test locally and in CI
- Added commitlint with Conventional Commits (pinned to v17 for CI stability)
- Updated ci.yml: commitlint, clippy, tests, build
- Added release.yml:
- Builds for Linux x86_64 and aarch64
- Generates SBOMs (CycloneDX) per target
- Produces SHA256SUMS
- Publishes GitHub Release with auto-generated changelog

## Documentation

- Linux-only support (x86_64 + aarch64)
- Install/update instructions
- Config file examples
- Explanation of keep policy and rollback
- CI/Taskfile integration